### PR TITLE
Fixed case in include files to make it compatible with unix systems

### DIFF
--- a/display/display.cpp
+++ b/display/display.cpp
@@ -1,4 +1,5 @@
-#include <Display.hpp>
+#include "display.hpp"
+#include <sys/types.h>
 
 /**
  * @brief Display initialization

--- a/display/display.cpp
+++ b/display/display.cpp
@@ -1,5 +1,4 @@
 #include "display.hpp"
-#include <sys/types.h>
 
 /**
  * @brief Display initialization

--- a/display/display.hpp
+++ b/display/display.hpp
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include <sys/types.h>
 
 #include "pico/stdlib.h"
 #include "pico/divider.h"

--- a/display/display_drivers/gc9a01/gc9a01.cpp
+++ b/display/display_drivers/gc9a01/gc9a01.cpp
@@ -1,4 +1,4 @@
-#include "GC9A01.hpp"
+#include "gc9a01.hpp"
 
 /**
  * @brief Initialize the display

--- a/display/display_drivers/gc9a01/gc9a01.hpp
+++ b/display/display_drivers/gc9a01/gc9a01.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Display.hpp"
+#include "display.hpp"
 
 // Driver constants
 #define COMMAND_RAMWR 0x2c

--- a/display/display_drivers/st7789/st7789.cpp
+++ b/display/display_drivers/st7789/st7789.cpp
@@ -1,4 +1,4 @@
-#include "ST7789.hpp"
+#include "st7789.hpp"
 
 void ST7789::init()
 {    

--- a/display/display_drivers/st7789/st7789.hpp
+++ b/display/display_drivers/st7789/st7789.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Display.hpp"
+#include "display.hpp"
 
 // Driver constants
 #define COMMAND_RAMWR 0x2c

--- a/gauge/gauge.cpp
+++ b/gauge/gauge.cpp
@@ -1,4 +1,4 @@
-#include "Gauge.hpp"
+#include "gauge.hpp"
 
 /**
  * @brief Construct a new Dials object

--- a/gauge/gauge.hpp
+++ b/gauge/gauge.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Graphics.hpp"
+#include "graphics.hpp"
 
 // Constants
 #define DIAL_ANGLE 230  // Should be between 0 and 360 degrees

--- a/gradient/gradient.cpp
+++ b/gradient/gradient.cpp
@@ -1,4 +1,4 @@
-#include "Gradient.hpp"
+#include "gradient.hpp"
 #include <stdio.h>
 
 // create a global instance of the lookup tables

--- a/gradient/gradient.hpp
+++ b/gradient/gradient.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "Color.h"
-#include "Structs.h"
-#include "Shapes.h"
-#include "GfxMath.h"
+#include "color.h"
+#include "structs.h"
+#include "shapes.h"
+#include "gfxmath.h"
 
 class Gradient
 {

--- a/graphics/gfxmath.c
+++ b/graphics/gfxmath.c
@@ -1,4 +1,4 @@
-#include "GfxMath.h"
+#include "gfxmath.h"
 
 int cosTable[NUMBER_OF_ANGLES];
 int sinTable[NUMBER_OF_ANGLES];

--- a/graphics/graphics.cpp
+++ b/graphics/graphics.cpp
@@ -1,4 +1,4 @@
-#include "Graphics.hpp"
+#include "graphics.hpp"
 #include <stdio.h>
 
 /**

--- a/graphics/graphics.hpp
+++ b/graphics/graphics.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "Color.h"
-#include "Structs.h"
-#include "Shapes.h"
-#include "GfxMath.h"
+#include "color.h"
+#include "structs.h"
+#include "shapes.h"
+#include "gfxmath.h"
 
 class Graphics
 {

--- a/picogfx/picogfx.cpp
+++ b/picogfx/picogfx.cpp
@@ -1,4 +1,4 @@
-#include "PicoGFX.hpp"
+#include "picogfx.hpp"
 
 /**
  * @brief Get the Print object

--- a/picogfx/shapes.h
+++ b/picogfx/shapes.h
@@ -5,7 +5,7 @@ extern "C"
 {
 #endif
 
-#include "GfxMath.h"
+#include "gfxmath.h"
 
 struct Point
 {

--- a/print/print.cpp
+++ b/print/print.cpp
@@ -1,4 +1,4 @@
-#include "Print.hpp"
+#include "print.hpp"
 
 /**
  * @brief Construct a new Print object

--- a/print/print.hpp
+++ b/print/print.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "Color.h"
-#include "Structs.h"
-#include "Shapes.h"
-#include "FontStruct.h"
+#include "color.h"
+#include "structs.h"
+#include "shapes.h"
+#include "fontstruct.h"
 
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
Since the header file includes were created in a case insensitive system they do not work on case sensitive ones such as linux. This pull request addresses that by renaming the include files to their actual file names making it work on all platforms. Also `#include <sys/types.h>` was added to `PicoGFX/display/display.cpp` in order to provide the `ushort` type.

Below is an exhaustive list of changes:
```
PicoGFX/gauge/gauge.cpp:1:10 #include "Gauge.hpp" -> #include "gauge.hpp"
PicoGFX/picogfx/picogfx.cpp:1:10 #include "PicoGFX.hpp" -> #include "picogfx.hpp"
PicoGFX/display/display_drivers/st7789/st7789.cpp:1:10 #include "ST7789.hpp" -> #include "st7789.hpp"
PicoGFX/gradient/gradient.cpp:1:10 #include "Gradient.hpp" -> #include "gradient.hpp"
PicoGFX/display/display_drivers/gc9a01/gc9a01.cpp:1:10 #include "GC9A01.hpp" -> #include "gc9a01.hpp"
PicoGFX/graphics/graphics.cpp:1:10 #include "Graphics.hpp" -> #include "graphics.hpp"
PicoGFX/graphics/graphics.hpp:3:10 #include "Color.h" -> #include "color.h"
PicoGFX/graphics/graphics.hpp:4:10 #include "Structs.h" -> #include "structs.h"
PicoGFX/graphics/graphics.hpp:5:10 #include "Shapes.h" -> #include "shapes.h"
PicoGFX/graphics/graphics.hpp:6:10 #include "GfxMath.h" -> #include "gfxmath.h"
PicoGFX/display/display_drivers/gc9a01/gc9a01.hpp:3:10 #include "Display.hpp" -> #include "display.hpp"
PicoGFX/display/display.cpp:1:10 #include "Display.hpp" -> #include "display.hpp"
PicoGFX/display/display_drivers/st7789/st7789.hpp:3:10 "Display.hpp" -> #include "display.hpp"
PicoGFX/gauge/gauge.hpp:3:10 #include "Graphics.hpp" -> #include "graphics.hpp"
PicoGFX/graphics/gfxmath.c:1:10 #include "GfxMath.h" -> #include "gfxmath.h"
PicoGFX/gradient/gradient.hpp:3:10 #include "Color.h" -> #include "color.h"
PicoGFX/gradient/gradient.hpp:4:10 #include "Structs.h" -> #include "structs.h"
PicoGFX/gradient/gradient.hpp:5:10 #include "Shapes.h" -> #include "shapes.h"
PicoGFX/gradient/gradient.hpp:6:10 #include "GfxMath.h" -> #include "gfxmath.h"
PicoGFX/print/print.cpp:1:10 #include "Print.hpp" -> #include "print.hpp"
PicoGFX/print/print.hpp:3:10 #include "Color.h" -> #include "color.h"
PicoGFX/print/print.hpp:4:10 #include "Structs.h" -> #include "structs.h"
PicoGFX/print/print.hpp:5:10 #include "Shapes.h" -> #include "shapes.h"
PicoGFX/print/print.hpp:6:10 #include "FontStruct.h" -> #include "fontstruct.h"
PicoGFX/picogfx/shapes.h:8:10 #include "GfxMath.h" -> #include "gfxmath.h"
PicoGFX/display/display.cpp:138:36 error: 'ushort' has not been declared -> #include <sys/types.h>
```

